### PR TITLE
feat: add Bulls Connect redirect to Join Us buttons

### DIFF
--- a/src/features/hero/Components/HeroSection.tsx
+++ b/src/features/hero/Components/HeroSection.tsx
@@ -66,6 +66,12 @@ export default function HeroSection() {
               <Button
                 variant="primary"
                 className="font-bold bg-blue-600 hover:bg-blue-700 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 flex-1"
+                onClick={() => {
+                  window.open(
+                    "https://bullsconnect.usf.edu/gdsc/rsvp_boot?id=1984399",
+                    "_blank"
+                  );
+                }}
               >
                 Join Us
               </Button>

--- a/src/features/hero/Components/HeroSectionWrapper.tsx
+++ b/src/features/hero/Components/HeroSectionWrapper.tsx
@@ -105,6 +105,12 @@ export default function HeroSectionWrapper() {
               <Button
                 variant="primary"
                 className="font-bold bg-blue-600 hover:bg-blue-700 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 flex-1"
+                onClick={() => {
+                  window.open(
+                    "https://bullsconnect.usf.edu/gdsc/rsvp_boot?id=1984399",
+                    "_blank"
+                  );
+                }}
               >
                 Join Us
               </Button>


### PR DESCRIPTION
- Add onClick handlers to Join Us buttons in HeroSection and HeroSectionWrapper
- Both buttons now redirect to Bulls Connect registration page
- Maintains consistency with Register Now button behavior
- Opens in new tab to preserve user navigation